### PR TITLE
Fix argument order in remove_labels method call

### DIFF
--- a/mediux_posters/services/plex/service.py
+++ b/mediux_posters/services/plex/service.py
@@ -330,7 +330,7 @@ class Plex(BaseService[Show, Season, Episode, Collection, Movie]):
                             body=stream.read(),
                         )
                     if kometa_integration:
-                        self.remove_labels("Overlay", object_id=object_id)
+                        self.remove_labels(object_id, "Overlay")
                 return True
             except ServiceError as err:
                 LOGGER.error(


### PR DESCRIPTION
<img width="2076" height="1269" alt="image" src="https://github.com/user-attachments/assets/6f99b48e-57e1-4cea-bf23-a9eb4738e27d" />

This error happens when setting kometa integration to true. Whenever it attempts to remove the "overlay" tag, this function fails.